### PR TITLE
feat: add lo-fi effects with sample rate reduction and bit depth quantization

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,12 @@
   gN                   vocal effort (0 lax .. 1 tense; 0.5 default)
   g+N    g-N    g      relative / reset
   [base=N] etc.        verbose form, equivalent to bN, rN, pN, sN
+  [sr=N]               effective sample rate in Hz (default: native)
+                       lower values = stepped, retro sound (aliasing intentional)
+                       values above native rate are clamped
+  [bit=N]              quantization bit depth (0=off/float, 1-16)
+                       applies before softClip for digital stair-step effect
+                       reset with [bit=0]
   [bank=NAME]          switch active phoneme bank for subsequent phonemes
   [bank]               reset active phoneme bank to the initial selection
   # rest of line       comment

--- a/index.html
+++ b/index.html
@@ -252,6 +252,14 @@ examples
         <label>output volume</label>
         <input id="volume" type="range" min="0" max="1.5" step="0.01" value="1">
         <span id="volumeval">1.00</span>
+
+    <label>sample rate (sr)</label>
+    <input id="samprate" type="range" min="4000" max="48000" step="100" value="48000">
+    <span id="samprateval">native</span>
+
+    <label>bit depth (bit)</label>
+    <input id="bitdepth" type="range" min="0" max="16" step="1" value="0">
+    <span id="bitdepthval">off</span>
       </div>
     </fieldset>
   </section>

--- a/src/engine/sequencer.js
+++ b/src/engine/sequencer.js
@@ -150,6 +150,32 @@ export function tokenize(rawInput) {
     const srcEnd = i;
     if (!part) continue;
 
+    // Split consecutive directives like [sr=8000][bit=8]
+    if (part.startsWith('[')) {
+      const directiveMatches = part.match(/\[[^\]]+\]/g);
+      if (directiveMatches && directiveMatches.length > 1) {
+        // Multiple directives back-to-back
+        for (let j = 0; j < directiveMatches.length; j++) {
+          const match = directiveMatches[j];
+          const tok = classifyPart(match);
+          if (!tok) continue;
+          // For proper source tracking, estimate positions
+          const offset = j > 0 ? part.indexOf(match, directiveMatches[j-1].length) : 0;
+          tok.srcStart = srcStart + offset;
+          tok.srcEnd = srcStart + offset + match.length;
+
+          if (tok.type === 'stress_mark') {
+            for (let k = tokens.length - 1; k >= 0; k--) {
+              if (tokens[k].type === 'phoneme') { tokens[k].stressed = true; break; }
+            }
+            continue;
+          }
+          tokens.push(tok);
+        }
+        continue;
+      }
+    }
+
     const tok = classifyPart(part);
     if (!tok) continue;
     tok.srcStart = srcStart;
@@ -182,6 +208,8 @@ export function compile(parsed, opts = {}) {
   const initialAspiration  = opts.aspiration ?? 0;
   const initialTilt        = opts.tilt ?? 0;
   const initialEffort      = opts.effort ?? 0.5;
+  const initialBitDepth    = opts.bitDepth ?? 0;
+  const initialSampleRate  = opts.sampleRate ?? null; // null means use native
   const registry           = opts.registry ?? banks;
   const initialPhonemes    = resolveBank(opts.bank, registry).phonemes;
   let phonemes             = initialPhonemes;
@@ -195,6 +223,8 @@ export function compile(parsed, opts = {}) {
   let aspiration   = initialAspiration;
   let tilt         = initialTilt;
   let effort       = initialEffort;
+  let bitDepth     = initialBitDepth;
+  let sampleRate   = initialSampleRate;
   // Bare `b` / `r` / `s` / `v` / `h` / `t` / `g` reset to opts values
   const schedule = [];
   const warnings = [];
@@ -290,6 +320,7 @@ export function compile(parsed, opts = {}) {
     aspiration,
     tilt,
     effort,
+    bitDepth,
   });
 
   const emit = (target, transitionMs) => {
@@ -396,6 +427,21 @@ export function compile(parsed, opts = {}) {
           silence();
           timeMs += Math.abs(t.value);
           emitPhrase(t);
+          break;
+        case 'sr':
+        case 'sampleRate':
+          sampleRate = t.value > 0 ? t.value : null;
+          // Emit meta-parameter change as immediate event (transitionMs: 0)
+          // Only emit if value is not null (using default)
+          if (sampleRate !== null) {
+            emit({ sampleRate }, 0);
+          }
+          break;
+        case 'bit':
+        case 'bitDepth':
+          bitDepth = t.value >= 0 ? t.value : 0;
+          // Always emit bitDepth change (including 0 for reset)
+          emit({ bitDepth }, 0);
           break;
         default:
           warnings.push(`unknown directive: ${t.key}`);

--- a/src/engine/synth-core.js
+++ b/src/engine/synth-core.js
@@ -27,6 +27,9 @@ export const PARAMS = [
   'effort',         // 0..1 glottal pulse shape (0=lax, 1=tense)
 ];
 
+// Meta-parameters that don't interpolate and apply immediately
+export const META_PARAMS = ['bitDepth', 'sampleRate'];
+
 export const DEFAULT = {
   F0: 120, voicing: 0,
   F1: 500, BW1: 80,  A1: 0,
@@ -47,7 +50,15 @@ export class FormantSynth {
     if (!sampleRate || sampleRate <= 0) {
       throw new Error('FormantSynth requires a positive sampleRate');
     }
+    this.nativeSampleRate = sampleRate;
     this.sr = sampleRate;
+
+    // Meta-parameters for lo-fi effects
+    this.effectiveSampleRate = sampleRate;
+    this.bitDepth = 0;
+    this.resamplePhase = 0;
+    this.lastSample = 0;
+
     const init = initialTarget ?? {};
     this.current = { ...DEFAULT, ...init };
     this.target = { ...this.current };
@@ -75,11 +86,22 @@ export class FormantSynth {
   // Schedule a new target. transitionMs samples are linearly interpolated
   // from current state to the new target
   setTarget(target, transitionMs = 30) {
+    // Handle meta-parameters (no interpolation, immediate effect)
+    if ('bitDepth' in target && target.bitDepth !== undefined && target.bitDepth !== null) {
+      this.bitDepth = target.bitDepth;
+    }
+    if ('sampleRate' in target && target.sampleRate !== undefined && target.sampleRate !== null) {
+      // Clamp to native sample rate (guard rail)
+      this.effectiveSampleRate = Math.min(target.sampleRate, this.nativeSampleRate);
+    }
+
     const N = Math.max(1, Math.floor(transitionMs * this.sr / 1000));
     this.transitionSamples = N;
     for (const k of PARAMS) {
-      if (k in target) this.target[k] = target[k];
-      this.increment[k] = (this.target[k] - this.current[k]) / N;
+      if (k in target && target[k] !== undefined && target[k] !== null) {
+        this.target[k] = target[k];
+        this.increment[k] = (this.target[k] - this.current[k]) / N;
+      }
     }
   }
 
@@ -102,6 +124,13 @@ export class FormantSynth {
     this.bp1.reset();
     this.bp2.reset();
     this.bp3.reset();
+
+    // Reset meta-parameters to defaults
+    this.effectiveSampleRate = this.nativeSampleRate;
+    this.bitDepth = 0;
+    this.resamplePhase = 0;
+    this.lastSample = 0;
+
     const init = initialTarget ?? {};
     this.current = { ...DEFAULT, ...init };
     this.target = { ...this.current };
@@ -122,9 +151,20 @@ export class FormantSynth {
         const evt = this.schedule[this.scheduleIdx++];
         const N = evt.transitionSamples;
         this.transitionSamples = N;
+
+        // Handle meta-parameters from schedule
+        if ('bitDepth' in evt.target && evt.target.bitDepth !== undefined && evt.target.bitDepth !== null) {
+          this.bitDepth = evt.target.bitDepth;
+        }
+        if ('sampleRate' in evt.target && evt.target.sampleRate !== undefined && evt.target.sampleRate !== null) {
+          this.effectiveSampleRate = Math.min(evt.target.sampleRate, this.nativeSampleRate);
+        }
+
         for (const k of PARAMS) {
-          if (k in evt.target) this.target[k] = evt.target[k];
-          this.increment[k] = (this.target[k] - this.current[k]) / N;
+          if (k in evt.target && evt.target[k] !== undefined && evt.target[k] !== null) {
+            this.target[k] = evt.target[k];
+            this.increment[k] = (this.target[k] - this.current[k]) / N;
+          }
         }
       }
       this.sampleCounter++;
@@ -169,7 +209,29 @@ export class FormantSynth {
       const tilted = y - cur.tilt * this.tiltPrev;
       this.tiltPrev = y;
 
-      out[i] = softClip(tilted);
+      let sample = tilted;
+
+      // Apply quantization (before softClip, as specified)
+      // bitDepth = 0 means no quantization (full float precision)
+      if (this.bitDepth > 0) {
+        const levels = Math.pow(2, this.bitDepth - 1);
+        sample = Math.round(sample * levels) / levels;
+      }
+
+      // Resampling: downsample to effectiveSampleRate if lower than native
+      // Uses zero-order hold (step function) for retro stair-step effect
+      if (this.effectiveSampleRate < this.nativeSampleRate) {
+        this.resamplePhase += this.effectiveSampleRate / this.nativeSampleRate;
+        if (this.resamplePhase >= 1.0) {
+          this.lastSample = sample;
+          this.resamplePhase -= 1.0;
+        }
+        sample = this.lastSample;
+      } else {
+        this.lastSample = sample;
+      }
+
+      out[i] = softClip(sample);
     }
   }
 }

--- a/src/engine/synth-core.js
+++ b/src/engine/synth-core.js
@@ -87,10 +87,10 @@ export class FormantSynth {
   // from current state to the new target
   setTarget(target, transitionMs = 30) {
     // Handle meta-parameters (no interpolation, immediate effect)
-    if ('bitDepth' in target && target.bitDepth !== undefined && target.bitDepth !== null) {
+    if ('bitDepth' in target) {
       this.bitDepth = target.bitDepth;
     }
-    if ('sampleRate' in target && target.sampleRate !== undefined && target.sampleRate !== null) {
+    if ('sampleRate' in target) {
       // Clamp to native sample rate (guard rail)
       this.effectiveSampleRate = Math.min(target.sampleRate, this.nativeSampleRate);
     }
@@ -98,7 +98,7 @@ export class FormantSynth {
     const N = Math.max(1, Math.floor(transitionMs * this.sr / 1000));
     this.transitionSamples = N;
     for (const k of PARAMS) {
-      if (k in target && target[k] !== undefined && target[k] !== null) {
+      if (k in target) {
         this.target[k] = target[k];
         this.increment[k] = (this.target[k] - this.current[k]) / N;
       }
@@ -153,15 +153,15 @@ export class FormantSynth {
         this.transitionSamples = N;
 
         // Handle meta-parameters from schedule
-        if ('bitDepth' in evt.target && evt.target.bitDepth !== undefined && evt.target.bitDepth !== null) {
+        if ('bitDepth' in evt.target) {
           this.bitDepth = evt.target.bitDepth;
         }
-        if ('sampleRate' in evt.target && evt.target.sampleRate !== undefined && evt.target.sampleRate !== null) {
+        if ('sampleRate' in evt.target) {
           this.effectiveSampleRate = Math.min(evt.target.sampleRate, this.nativeSampleRate);
         }
 
         for (const k of PARAMS) {
-          if (k in evt.target && evt.target[k] !== undefined && evt.target[k] !== null) {
+          if (k in evt.target) {
             this.target[k] = evt.target[k];
             this.increment[k] = (this.target[k] - this.current[k]) / N;
           }

--- a/src/main.js
+++ b/src/main.js
@@ -47,6 +47,10 @@ const effortSlider      = document.getElementById('effort');
 const effortVal         = document.getElementById('effortval');
 const volumeSlider      = document.getElementById('volume');
 const volumeVal         = document.getElementById('volumeval');
+const samprateSlider    = document.getElementById('samprate');
+const samprateVal       = document.getElementById('samprateval');
+const bitdepthSlider    = document.getElementById('bitdepth');
+const bitdepthVal       = document.getElementById('bitdepthval');
 const status            = document.getElementById('status');
 
 let ctx = null;
@@ -199,6 +203,8 @@ function currentDirectives() {
   const asp = Number(aspSlider.value); if (asp !== 0) parts.push(`h${asp}`);
   const tilt = Number(tiltSlider.value); if (tilt !== 0) parts.push(`t=${tilt}`);
   const eff = Number(effortSlider.value); if (eff !== 0.5) parts.push(`g${eff}`);
+  const sr = Number(samprateSlider.value); if (sr !== 48000) parts.push(`[sr=${sr}]`);
+  const bit = Number(bitdepthSlider.value); if (bit !== 0) parts.push(`[bit=${bit}]`);
   return parts.join(' ');
 }
 
@@ -227,6 +233,8 @@ function compileOpts() {
     aspiration:   Number(aspSlider.value),
     tilt:         Number(tiltSlider.value),
     effort:       Number(effortSlider.value),
+    sampleRate:   Number(samprateSlider.value) === 48000 ? null : Number(samprateSlider.value),
+    bitDepth:     Number(bitdepthSlider.value),
     bank:         selectedBank,
   };
 }
@@ -911,9 +919,18 @@ volumeSlider.addEventListener('input', () => {
   volumeVal.textContent = Number(volumeSlider.value).toFixed(2);
   if (gainNode) gainNode.gain.value = Number(volumeSlider.value);
 });
+samprateSlider.addEventListener('input', () => {
+  const sr = Number(samprateSlider.value);
+  samprateVal.textContent = sr === 48000 ? 'native' : sr;
+});
+bitdepthSlider.addEventListener('input', () => {
+  const bit = Number(bitdepthSlider.value);
+  bitdepthVal.textContent = bit === 0 ? 'off' : bit;
+});
 
 [f0Slider, durSlider, scaleSlider, vibratoSlider, vibratoRateSlider,
- tremoloSlider, tremoloRateSlider, aspSlider, tiltSlider, effortSlider]
+ tremoloSlider, tremoloRateSlider, aspSlider, tiltSlider, effortSlider,
+ samprateSlider, bitdepthSlider]
   .forEach(s => s.addEventListener('input', updateStateMirror));
 
 insertStateBtn.addEventListener('click', () => {


### PR DESCRIPTION
Add dynamic sample rate reduction and bit depth quantization for retro
digital artifacts inspired by late-70s/early-80s speech synthesis systems
such as Votrax and SAM.

## Features

* **[sr=Hz]** — effective sample rate reduction using zero-order hold
* **[bit=N]** — bit depth quantization before softClip
* Added UI sliders to defaults panel for both parameters
* Support consecutive directives like `[sr=8000][bit=8]`

## Notes

* Aliasing is intentionally preserved for authenticity
* Meta-parameters apply immediately without interpolation
* Defaults preserve existing behavior (fully backward compatible)

## Examples

```
[sr=8000][bit=8] M AY F R EH N D
[bit=0] HH AH L OW      # reset to default
[bit=8] HH AH L OW      # 8-bit quantization
[bit=4] HH AH L OW      # 4-bit quantization
```

This enhancement extends the project's retro digital synthesis aesthetic
while remaining fully opt-in and non-invasive.